### PR TITLE
Group statistics per site group

### DIFF
--- a/src/CookieBanner.php
+++ b/src/CookieBanner.php
@@ -55,7 +55,8 @@ class CookieBanner extends Plugin
 
         Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function (RegisterUrlRulesEvent $event) {
             $event->rules['cookie-banner/statistics'] = 'cookie-banner/statistics/render-index';
-            $event->rules['cookie-banner/statistics/table-view/<siteId:\d+>'] = 'cookie-banner/statistics/table-view';
+            $event->rules['cookie-banner/statistics/table-view-site/<siteId:\d+>'] = 'cookie-banner/statistics/table-view-site';
+            $event->rules['cookie-banner/statistics/table-view-group/<groupId:\d+>'] = 'cookie-banner/statistics/table-view-group';
         });
     }
 

--- a/src/controllers/StatisticsController.php
+++ b/src/controllers/StatisticsController.php
@@ -11,13 +11,19 @@ class StatisticsController extends Controller
 {
     protected int|bool|array $allowAnonymous = [];
 
-    public function actionRenderIndex(int $siteId = 0): Response
+    public function actionRenderIndex(int $groupId = 0, int $siteId = 0): Response
     {
         // INFO: we invent empty site to represent all sites
         $site = ['name' => 'All sites', 'id' => 0, 'handle' => 'all'];
 
+        $siteIds = null;
         if ($siteId) {
             $site = \Craft::$app->sites->getSiteById($siteId);
+        }
+
+        if($groupId) {
+            $sites = \Craft::$app->getSites()->getSitesByGroupId($groupId);
+            $siteIds = collect($sites)->pluck('id')->all();
         }
 
         $records = CookieTrackingRecord::find()->orderBy('sectionDate DESC')->all();
@@ -27,7 +33,7 @@ class StatisticsController extends Controller
         $settingsCookies = 0;
         /** @var CookieTrackingRecord $record */
         foreach($records as $record) {
-            if ($siteId && $siteId !== $record->siteId) {
+            if ($siteIds && !in_array($record->siteId, $siteIds)) {
                 continue;
             }
 
@@ -58,22 +64,42 @@ class StatisticsController extends Controller
         return $this->renderTemplate('cookie-banner/_cp/_statistics', $context);
     }
 
-    public function actionTableView(int $siteId, int $page = 1): Response
+    public function actionTableViewSite(int $siteId, int $page = 1): Response
     {
+        if($siteId === 0) {
+            $sites = \Craft::$app->getSites()->getAllSites();
+            $siteIds = collect($sites)->pluck('id')->all();
+            $rows = $this->parseDataForTable($siteIds);
+        } else {
+            $rows = $this->parseDataForTable([$siteId]);
+        }
+
+        return $this->returnAdminTableResult($rows, sprintf('cookie-banner/statistics/table-view-site/%s', $siteId), $page);
+    }
+
+    public function actionTableViewGroup(int $groupId, int $page = 1): Response
+    {
+        $sites = \Craft::$app->getSites()->getSitesByGroupId($groupId);
+        $siteIds = collect($sites)->pluck('id')->all();
+        $rows = $this->parseDataForTable($siteIds);
+        return $this->returnAdminTableResult($rows, sprintf('cookie-banner/statistics/table-view-group/%s', $groupId), $page);
+    }
+
+
+    private function parseDataForTable(array $sites = []) {
         $rows = [];
         $records = CookieTrackingRecord::find()->orderBy('sectionDate DESC')->all();
-
         /** @var CookieTrackingRecord $record */
         foreach ($records as $record) {
-            if ($siteId != 0 && $siteId !== $record->siteId) {
+            if ($sites && !in_array($record->siteId, $sites)) {
                 continue;
             }
 
             $title = \DateTimeImmutable::createFromFormat('Y-m', $record->sectionDate)->format('F Y');
-            if($siteId === 0) {
+
                 $siteName = \Craft::$app->sites->getSiteById($record->siteId)->name;
                 $title = $title . ' - ' . $siteName;
-            }
+
             $total = $record->accept + $record->deny + $record->settings;
 
             $row = [
@@ -84,8 +110,7 @@ class StatisticsController extends Controller
             ];
             $rows[] = $row;
         }
-
-        return $this->returnAdminTableResult($rows, sprintf('cookie-banner/statistics/table-view/%s', $siteId), $page);
+        return $rows;
     }
 
     private function returnAdminTableResult(array $rows, string $baseUrl, int $page): Response

--- a/src/templates/_cp/_sites.twig
+++ b/src/templates/_cp/_sites.twig
@@ -1,21 +1,19 @@
-{% if craft.app.sites.getEditableSites()|length > 1 %}
-    <div id="revision-btn" class="btn menubtn" data-icon="world">{{ selectedSite.name }}</div>
-    <div class="menu">
-        <ul class="padded">
-                <li>
-                    <a href="{{ url('/admin/cookie-banner/statistics?siteId=0' ) }}"
-                       {% if 'all' == selectedSite.handle %}class="sel"{% endif %}>
-                        {{ 'All sites'|t }}
-                    </a>
-                </li>
-            {% for site in craft.app.sites.getAllSites() %}
-                <li>
-                    <a href="{{ url('/admin/cookie-banner/statistics?siteId=' ~ site.id ) }}"
-                       {% if site.handle == selectedSite.handle %}class="sel"{% endif %}>
-                        {{ site.name }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
-{% endif %}
+<div id="revision-btn" class="btn menubtn" data-icon="world">{{ selectedSite.name }}</div>
+<div class="menu">
+    <ul class="padded">
+        <li>
+            <a href="{{ url('/admin/cookie-banner/statistics', { groupId : groupId, siteId : 0 } ) }}"
+               {% if 'all' == selectedSite.handle %}class="sel"{% endif %}>
+                {{ 'All sites'|t }}
+            </a>
+        </li>
+        {% for site in sites %}
+            <li>
+                <a href="{{ url('/admin/cookie-banner/statistics', { groupId: groupId, siteId : site.id} ) }}"
+                   {% if site.handle == selectedSite.handle %}class="sel"{% endif %}>
+                    {{ site.name }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/src/templates/_cp/_statistics.twig
+++ b/src/templates/_cp/_statistics.twig
@@ -7,10 +7,43 @@
     { label: 'Cookie acceptance statistics', url: '#' }
 ] %}
 
+{% set groupId = craft.app.request.getParam('groupId') %}
+{% set siteGroups = craft.app.sites.getAllGroups() %}
+
 {% block contextMenu %}
-    {% if selectedSubnavItem == 'defaults' %}
-        {% include 'cookie-banner/_cp/_sites.twig' %}
+    {% if groupId %}
+        {% set sites = craft.app.sites.getSitesByGroupId(groupId) %}
+    {% elseif siteGroups|length == 1 %}
+        {% set sites = craft.app.sites.getAllSites() %}
     {% endif %}
+    {% if sites is defined %}
+        {% include 'cookie-banner/_cp/_sites.twig' with { sites: sites, groupId : groupId ?? null } %}
+    {% endif %}
+{% endblock %}
+
+
+{% block sidebar %}
+    <nav>
+        <ul id="groups">
+            <li>
+                <a href="{{ url('cookie-banner/statistics') }}"{% if not groupId %} class="sel"{% endif %}>{{ "All Sites"|t('app') }}</a>
+            </li>
+            {% for g in siteGroups %}
+                <li>
+                    {{ tag('a', {
+                        href: url('cookie-banner/statistics/', {groupId: g.id}),
+                        class: groupId and g.id == groupId ? 'sel' : false,
+                        text: g.name|t('site'),
+                        data: {
+                            id: g.id,
+                            'raw-name': g.getName(false),
+                        },
+                    }) }}
+                </li>
+            {% endfor %}
+
+        </ul>
+    </nav>
 {% endblock %}
 
 {% block content %}
@@ -21,7 +54,7 @@
                     <div class="pane">
                         <div class="body">
                             <h2 style="margin-bottom: 0;">{{ 'Cookies'|t }}</h2>
-                            <p style="font-size: 0.7rem; margin-top: 0;">{{ 'Cookie statistics are being tracked since'|t }} {{ firstRecordDate}}</p>
+                            <p style="font-size: 0.7rem; margin-top: 0;">{{ 'Cookie statistics are being tracked since'|t }} {{ firstRecordDate }}</p>
                             {% include('cookie-banner/_cp/_widgets/_total_cookies.twig')|raw %}
                         </div>
                     </div>
@@ -51,16 +84,21 @@
     { name: 'settings', title: "Settings" },
 ] %}
 {% set actions = [] %}
-{% set endpoint = '/admin/cookie-banner/statistics/table-view/' ~ selectedSite.id %}
+
+{% if (groupId and (selectedSite and selectedSite.id > 0)) or not groupId %}
+    {% set endpoint = '/admin/cookie-banner/statistics/table-view-site/' ~ selectedSite.id %}
+{% else %}
+    {% set endpoint = '/admin/cookie-banner/statistics/table-view-group/' ~ groupId %}
+{% endif %}
 
 {% js %}
     new Craft.VueAdminTable({
-        container: '#cookie-table',
-        columns: {{ columnsVotes|json_encode|raw }},
-        tableDataEndpoint: "{{ endpoint }}" ,
-        checkboxes:  0,
-        allowMultipleSelections: false,
-        perPage: 100,
-        actions: {{ actions|json_encode|raw }},
+    container: '#cookie-table',
+    columns: {{ columnsVotes|json_encode|raw }},
+    tableDataEndpoint: "{{ endpoint }}" ,
+    checkboxes:  0,
+    allowMultipleSelections: false,
+    perPage: 100,
+    actions: {{ actions|json_encode|raw }},
     });
 {% endjs %}


### PR DESCRIPTION
This is a first attempt at #24. I moved the site groups to a sidebar, resulting in this:
![Screenshot 20240327-195657-CDhSB0tF](https://github.com/statikbe/craft-cookie-banner/assets/755428/600a2ce4-d84d-4c62-9283-fc95a8648c71)

- Sidebar is always visible since twig doesn't allow blocks to be wrapped in a condition. So we always show "All sites" and then the 1 default site group.
- Site switcher is visible only when clicking on a specific group
